### PR TITLE
fixed replace excluding rest of the patched object

### DIFF
--- a/src/test/scala/de/lenabrueder/rfc6902/JsonPatchSpec.scala
+++ b/src/test/scala/de/lenabrueder/rfc6902/JsonPatchSpec.scala
@@ -28,6 +28,12 @@ class JsonPatchSpec extends WordSpec with Matchers {
       patch.right.get(json) should equal(Right(json))
     }
 
+    "support the \"replace\" functionality" in {
+      val patch = JsPatch(Json.parse("""[{"op":"replace", "path":"/a", "value":"g"}]"""))
+      patch shouldBe 'right
+      patch.right.get(json) should equal(Right(Json.parse("""{"a":"g", "b":{"c":"d"}}""")))
+    }
+
     "fail when no \"value\" is given for operation \"replace\" in the patch" in {
       val patch = JsPatch(Json.parse("""[{"op":"replace", "path":"/b"}]"""))
       patch shouldBe 'left


### PR DESCRIPTION
Hey Lena,

test case was added regarding the replace bug, where the operation would exclude the rest of the patched object. Add op was also fixed.